### PR TITLE
Resolved deprecation warnings + version bump

### DIFF
--- a/artifact/download/action.yml
+++ b/artifact/download/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Set artifact name
       id: set-artifact-name
-      uses: radiant-maxar/geoint-actions/artifact/set-name@v1.1
+      uses: radiant-maxar/geoint-actions/artifact/set-name@v1.2
       with:
         el_version: ${{ inputs.el_version }}
 

--- a/artifact/set-name/action.yml
+++ b/artifact/set-name/action.yml
@@ -19,5 +19,5 @@ runs:
       id: set-artifact-name
       run: |
         REPO_NAME="$(echo '${{ github.repository }}' | sed 's#^${{ github.repository_owner }}/##')"
-        echo "::set-output name=artifact-name::${REPO_NAME}.${{ inputs.el_version }}.${{ github.sha }}"
+        echo "artifact-name=${REPO_NAME}.${{ inputs.el_version }}.${{ github.sha }}" >> $GITHUB_OUTPUT
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/artifact/upload/action.yml
+++ b/artifact/upload/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Set artifact name
       id: set-artifact-name
-      uses: radiant-maxar/geoint-actions/artifact/set-name@v1.1
+      uses: radiant-maxar/geoint-actions/artifact/set-name@v1.2
       with:
         el_version: ${{ inputs.el_version }}
 

--- a/build/action.yml
+++ b/build/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Download RPMS artifact
       if: inputs.download_rpms
-      uses: radiant-maxar/geoint-actions/artifact/download@v1.1
+      uses: radiant-maxar/geoint-actions/artifact/download@v1.2
       with:
         base_path: ${{ inputs.base_path }}
         directory: RPMS
@@ -51,7 +51,7 @@ runs:
       working-directory: ${{ inputs.base_path }}
 
     - name: Log in to GHCR
-      uses: radiant-maxar/geoint-actions/docker/registry-login@v1.1
+      uses: radiant-maxar/geoint-actions/docker/registry-login@v1.2
       with:
         server: ${{ inputs.image_registry }}
 
@@ -82,7 +82,7 @@ runs:
 
     - name: Upload RPMS artifact
       if: inputs.upload_rpms
-      uses: radiant-maxar/geoint-actions/artifact/upload@v1.1
+      uses: radiant-maxar/geoint-actions/artifact/upload@v1.2
       with:
         base_path: ${{ inputs.base_path }}
         directory: RPMS

--- a/repository/create/action.yml
+++ b/repository/create/action.yml
@@ -35,7 +35,7 @@ runs:
 
   steps:
     - name: Log in to GHCR
-      uses: radiant-maxar/geoint-actions/docker/registry-login@v1.1
+      uses: radiant-maxar/geoint-actions/docker/registry-login@v1.2
       with:
         server: ${{ inputs.image_registry }}
 


### PR DESCRIPTION
> The `set-output` command is deprecated and will be disabled soon

I.E.
![image](https://user-images.githubusercontent.com/6109326/198704158-51014961-9a1a-4c00-a758-cbd89abf316b.png)
(https://github.com/radiant-maxar/geoint-deps/actions/runs/3339116215)


https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/